### PR TITLE
Add File Organizer plugin

### DIFF
--- a/plugins/plugins/file_organizer_plugin.py
+++ b/plugins/plugins/file_organizer_plugin.py
@@ -1,0 +1,184 @@
+"""File Organizer plugin for managing and deduplicating files."""
+
+import threading
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox
+import logging
+
+from processors.file_organizer_processor import (
+    scan_for_duplicates,
+    move_files,
+    delete_files,
+    _get_db,
+)
+from utils.config_manager import load_config, save_config
+
+logger = logging.getLogger(__name__)
+
+CONFIG_KEY = "file_organizer"
+
+
+def _load_prefs():
+    cfg = load_config()
+    return cfg.get(CONFIG_KEY, {})
+
+
+def _save_prefs(data):
+    cfg = load_config()
+    cfg[CONFIG_KEY] = data
+    save_config(cfg)
+
+
+class OrganizerUI:
+    def __init__(self, tab, plugin_api):
+        self.tab = tab
+        self.api = plugin_api
+        self.paths = []
+        prefs = _load_prefs()
+        self.recursive = tk.BooleanVar(value=prefs.get("recursive", True))
+        self.use_hash = tk.BooleanVar(value=prefs.get("use_hash", True))
+        self.dry_run = tk.BooleanVar(value=False)
+        self.schedule = tk.BooleanVar(value=prefs.get("schedule", False))
+        self.interval = tk.IntVar(value=prefs.get("interval", 24))
+        self._timer = None
+        self._build_ui()
+        if self.schedule.get():
+            self._schedule_scan()
+
+    def _build_ui(self):
+        path_frame = ttk.LabelFrame(self.tab, text="Scan Paths")
+        path_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+        self.listbox = tk.Listbox(path_frame, selectmode=tk.BROWSE)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+        btn_frame = ttk.Frame(path_frame)
+        btn_frame.pack(side=tk.RIGHT, fill=tk.Y)
+        ttk.Button(btn_frame, text="Add", command=self._add_path).pack(fill=tk.X, pady=2)
+        ttk.Button(btn_frame, text="Remove", command=self._remove_sel).pack(fill=tk.X, pady=2)
+
+        opts = ttk.Frame(self.tab)
+        opts.pack(fill=tk.X, padx=5)
+        ttk.Checkbutton(opts, text="Scan subdirectories", variable=self.recursive).pack(side=tk.LEFT)
+        ttk.Checkbutton(opts, text="Identify duplicates by content", variable=self.use_hash).pack(side=tk.LEFT)
+        ttk.Checkbutton(opts, text="Dry run", variable=self.dry_run).pack(side=tk.LEFT)
+        ttk.Checkbutton(opts, text="Daily Scan", variable=self.schedule, command=self._toggle_schedule).pack(side=tk.LEFT)
+        ttk.Label(opts, text="Interval(h)").pack(side=tk.LEFT, padx=2)
+        ttk.Spinbox(opts, from_=1, to=168, width=5, textvariable=self.interval).pack(side=tk.LEFT)
+
+        action_frame = ttk.Frame(self.tab)
+        action_frame.pack(fill=tk.X, padx=5, pady=5)
+        ttk.Button(action_frame, text="Scan", command=self._start_scan).pack(side=tk.LEFT)
+        ttk.Button(action_frame, text="Move To...", command=self._move_selected).pack(side=tk.LEFT, padx=2)
+        ttk.Button(action_frame, text="Copy To...", command=lambda: self._move_selected(copy=True)).pack(side=tk.LEFT, padx=2)
+        ttk.Button(action_frame, text="Delete", command=self._delete_selected).pack(side=tk.LEFT, padx=2)
+
+        self.tree = ttk.Treeview(self.tab, columns=("size", "path"), show="headings", selectmode="extended")
+        self.tree.heading("size", text="Key")
+        self.tree.heading("path", text="Path")
+        self.tree.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+    def _add_path(self):
+        path = filedialog.askdirectory(mustexist=True)
+        if not path:
+            return
+        self.paths.append(path)
+        self.listbox.insert(tk.END, path)
+
+    def _remove_sel(self):
+        sel = self.listbox.curselection()
+        if not sel:
+            return
+        idx = sel[0]
+        self.listbox.delete(idx)
+        del self.paths[idx]
+
+    def _toggle_schedule(self):
+        if self.schedule.get():
+            self._schedule_scan()
+        elif self._timer:
+            self._timer.cancel()
+            self._timer = None
+        _save_prefs({
+            "recursive": self.recursive.get(),
+            "use_hash": self.use_hash.get(),
+            "schedule": self.schedule.get(),
+            "interval": self.interval.get(),
+        })
+
+    def _schedule_scan(self):
+        if self._timer:
+            self._timer.cancel()
+        hours = self.interval.get()
+        self._timer = threading.Timer(hours * 3600, self._start_scan)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _start_scan(self):
+        if not self.paths:
+            messagebox.showerror("Error", "No paths selected")
+            return
+        data = {
+            "recursive": self.recursive.get(),
+            "use_hash": self.use_hash.get(),
+            "schedule": self.schedule.get(),
+            "interval": self.interval.get(),
+        }
+        _save_prefs(data)
+        threading.Thread(target=self._scan, daemon=True).start()
+
+    def _scan(self):
+        self.api.trigger_hook("organizer_pre_scan", self.paths)
+        conn = _get_db()
+        dupes = scan_for_duplicates(
+            self.paths,
+            recursive=self.recursive.get(),
+            use_hash=self.use_hash.get(),
+            fuzzy=False,
+            conn=conn,
+        )
+        self.tree.delete(*self.tree.get_children())
+        for key, paths in dupes.items():
+            for p in paths:
+                self.tree.insert("", tk.END, values=(key, p))
+        self.api.trigger_hook("organizer_post_action", dupes)
+
+    def _selected_files(self):
+        items = self.tree.selection()
+        return [self.tree.item(it)["values"][1] for it in items]
+
+    def _move_selected(self, copy=False):
+        files = self._selected_files()
+        if not files:
+            return
+        dest = filedialog.askdirectory()
+        if not dest:
+            return
+        if self.dry_run.get():
+            messagebox.showinfo("Dry Run", f"Would move {len(files)} files to {dest}")
+            return
+        move_files(files, dest, delete=not copy)
+        self._start_scan()
+
+    def _delete_selected(self):
+        files = self._selected_files()
+        if not files:
+            return
+        if messagebox.askyesno("Delete", f"Delete {len(files)} files?"):
+            if self.dry_run.get():
+                messagebox.showinfo("Dry Run", f"Would delete {len(files)} files")
+                return
+            delete_files(files)
+            self._start_scan()
+
+def register_plugin(plugin_api):
+    tab = ttk.Frame(plugin_api.app.notebook)
+    plugin_api.add_tab("File Organizer", tab)
+    ui = OrganizerUI(tab, plugin_api)
+
+    def run_last_scan():
+        ui._start_scan()
+
+    plugin_api.register_hook("preset:Scan Duplicates", run_last_scan)
+    plugin_api.register_hook("list_presets", lambda: ["Scan Duplicates"])
+    plugin_api.register_hook("organizer_pre_scan", lambda paths: None)
+    plugin_api.register_hook("organizer_post_action", lambda results: None)
+

--- a/processors/file_organizer_processor.py
+++ b/processors/file_organizer_processor.py
@@ -1,0 +1,127 @@
+"""File organizer processing utilities."""
+import os
+import hashlib
+import sqlite3
+import shutil
+import logging
+from typing import Iterable, Dict, List
+
+logger = logging.getLogger(__name__)
+
+CACHE_DB = "file_cache.db"
+
+
+def _get_db(db_path: str = CACHE_DB):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS hashes (path TEXT PRIMARY KEY, mtime REAL, size INTEGER, hash TEXT)"
+    )
+    return conn
+
+
+def compute_hash(file_path: str, conn=None) -> str:
+    """Return md5 hash of file, using cache if available."""
+    if conn is None:
+        conn = _get_db()
+    mtime = os.path.getmtime(file_path)
+    size = os.path.getsize(file_path)
+    cur = conn.execute(
+        "SELECT hash FROM hashes WHERE path=? AND mtime=? AND size=?",
+        (file_path, mtime, size),
+    )
+    row = cur.fetchone()
+    if row:
+        return row[0]
+    hash_md5 = hashlib.md5()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            hash_md5.update(chunk)
+    digest = hash_md5.hexdigest()
+    conn.execute(
+        "REPLACE INTO hashes(path, mtime, size, hash) VALUES (?,?,?,?)",
+        (file_path, mtime, size, digest),
+    )
+    conn.commit()
+    return digest
+
+
+def _get_files(paths: Iterable[str], recursive: bool) -> List[str]:
+    """Yield all files under the given paths."""
+    found = []
+    for p in paths:
+        if os.path.isfile(p):
+            found.append(p)
+        elif os.path.isdir(p):
+            if recursive:
+                for root, _, files in os.walk(p):
+                    for f in files:
+                        found.append(os.path.join(root, f))
+            else:
+                for f in os.listdir(p):
+                    fp = os.path.join(p, f)
+                    if os.path.isfile(fp):
+                        found.append(fp)
+    return found
+
+
+def scan_for_duplicates(
+    paths: Iterable[str],
+    recursive: bool = True,
+    use_hash: bool = True,
+    fuzzy: bool = False,
+    conn=None,
+) -> Dict[str, List[str]]:
+    """Return mapping of hash/size key to list of duplicate file paths."""
+    if conn is None:
+        conn = _get_db()
+    files = _get_files(paths, recursive)
+    groups: Dict[str, List[str]] = {}
+    for fp in files:
+        try:
+            size = os.path.getsize(fp)
+        except OSError as exc:
+            logger.error("Failed to stat %s: %s", fp, exc)
+            continue
+        key = str(size)
+        if use_hash:
+            try:
+                key = compute_hash(fp, conn)
+            except Exception as exc:
+                logger.error("Hash failed for %s: %s", fp, exc)
+                continue
+        groups.setdefault(key, []).append(fp)
+
+    # Filter out singletons
+    dupes = {k: v for k, v in groups.items() if len(v) > 1}
+    if fuzzy:
+        # Very naive fuzzy matching based on file names ignoring extension
+        name_map: Dict[str, List[str]] = {}
+        for fp in files:
+            base = os.path.splitext(os.path.basename(fp))[0].lower()
+            name_map.setdefault(base, []).append(fp)
+        for k, v in name_map.items():
+            if len(v) > 1:
+                dupes.setdefault(f"fuzzy:{k}", []).extend(v)
+    return dupes
+
+
+def move_files(files: Iterable[str], target_dir: str, delete: bool = False) -> None:
+    os.makedirs(target_dir, exist_ok=True)
+    for fp in files:
+        name = os.path.basename(fp)
+        dest = os.path.join(target_dir, name)
+        shutil.copy2(fp, dest)
+        if delete:
+            os.remove(fp)
+            logger.info("Moved and deleted %s", fp)
+        else:
+            logger.info("Copied %s", fp)
+
+
+def delete_files(files: Iterable[str]) -> None:
+    for fp in files:
+        try:
+            os.remove(fp)
+            logger.info("Deleted %s", fp)
+        except Exception as exc:
+            logger.error("Failed to delete %s: %s", fp, exc)

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -1,0 +1,18 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+from processors import file_organizer_processor as fop
+
+def test_scan_for_duplicates(tmp_path):
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    c = tmp_path / "c.txt"
+    a.write_text("same")
+    b.write_text("same")
+    c.write_text("diff")
+    conn = fop._get_db(str(tmp_path / "cache.db"))
+    dupes = fop.scan_for_duplicates([str(tmp_path)], recursive=False, conn=conn)
+    # Expect one group of duplicates containing a and b
+    values = list(dupes.values())
+    assert any({str(a), str(b)} <= set(group) for group in values)
+


### PR DESCRIPTION
## Summary
- create new file organizer processor to scan and manage duplicate files
- implement File Organizer plugin with basic UI and preset hook
- add unit test for duplicate scanning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dec1103dc832f8bc79bcb03da3a83