### PR TITLE
Improve thread handling across plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ This application uses small self-contained agents to handle major features. Each
 - **Key Methods**:
   - `__init__()` – create each agent and finalize setup.
   - `add_plugin_tab(title, frame)` – delegate to `UIAgent.add_plugin_tab`.
+  - `start_thread(*args, **kwargs)` – launch a daemon thread tracked for shutdown.
 
 These agents are loosely coupled and interact through the main `AppCore` object which exposes shared resources like the Tk root window. Plugins interact with the system via `PluginAgent` and `PluginAPI`.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Core functionality is organized into small **agents** in the `agents/` package. 
 ### Global Hotkeys & Tray
 - Assign custom shortcuts to start presets even when the app is in the background.
 - Minimize to system tray with quick actions and notifications.
+- Worker threads are tracked and joined on exit for a clean shutdown.
 
 ### Context Menus
 - Right-click drop areas for actions like **Apply Preset**, **Open File Location**, and **Copy Path**.

--- a/agents/tray_agent.py
+++ b/agents/tray_agent.py
@@ -40,7 +40,10 @@ class TrayAgent:
         return menu
 
     def show(self) -> None:
-        threading.Thread(target=self.icon.run, daemon=True).start()
+        if hasattr(self.app, "start_thread"):
+            self.app.start_thread(target=self.icon.run)
+        else:  # fallback
+            threading.Thread(target=self.icon.run, daemon=True).start()
 
     def _restore(self, icon=None, item=None):
         logger.info("Restoring window from tray")

--- a/agents/ui_agent.py
+++ b/agents/ui_agent.py
@@ -170,5 +170,9 @@ class UIAgent:
             self.app.tray.show()
 
     def _on_close(self) -> None:
+        # Gracefully stop any running worker threads
+        for t in getattr(self.app, "threads", []):
+            if t.is_alive():
+                t.join(timeout=1)
         self.app.tray.icon.stop()
         self.root.destroy()

--- a/code_analysis.md
+++ b/code_analysis.md
@@ -220,7 +220,7 @@ This document provides a comprehensive code analysis of the Multi-Utility App pr
 - [x] Add `.gitignore` entry for `logs/*`.
 - [x] Refactor naming for PEP8 compliance across project.
 - [x] Implement or enforce plugin metadata (version, dependencies).
-- [ ] Track and gracefully shut down all threads on exit.
+- [x] Track and gracefully shut down all threads on exit.
 - [ ] Refactor all file paths to use `os.path.join` and user dirs.
 - [ ] Update documentation (`README.md`, `AGENTS.md`).
 - [ ] Expand and improve test coverage.
@@ -238,7 +238,6 @@ This document provides a comprehensive code analysis of the Multi-Utility App pr
 - `agents/logger_agent.py` and runtime log files are deleted.
 
 **Next Steps:**
-- Implement thread tracking and graceful shutdown in `app.py` and agents.
 - Refactor all file paths to use `os.path.join` and user directories (consider `appdirs`).
 - Update and sync documentation (`README.md`, `AGENTS.md`).
 - Expand and improve test coverage for all modules.

--- a/core/app_core.py
+++ b/core/app_core.py
@@ -26,6 +26,15 @@ class AppCore:
     def register_thread(self, thread):
         self.threads.append(thread)
 
+    def start_thread(self, *args, **kwargs):
+        """Launch a daemon thread and register it for shutdown."""
+        import threading
+
+        thread = threading.Thread(*args, **kwargs, daemon=True)
+        thread.start()
+        self.register_thread(thread)
+        return thread
+
     # Delegate tab addition for plugins
     def add_plugin_tab(self, title, frame):
         self.ui.add_plugin_tab(title, frame)

--- a/core/plugin_api.py
+++ b/core/plugin_api.py
@@ -16,3 +16,16 @@ class PluginAPI:
 
     def get_main_window(self):
         return self.app.root
+
+    def start_thread(self, *args, **kwargs):
+        """Start a daemon thread registered with the application."""
+        if hasattr(self.app, "start_thread"):
+            return self.app.start_thread(*args, **kwargs)
+        # Fallback for legacy app versions
+        import threading
+
+        thread = threading.Thread(*args, **kwargs, daemon=True)
+        thread.start()
+        if hasattr(self.app, "register_thread"):
+            self.app.register_thread(thread)
+        return thread

--- a/plugins/plugins/archive_plugin.py
+++ b/plugins/plugins/archive_plugin.py
@@ -1,6 +1,5 @@
 """Simple archive creation and extraction plugin."""
 
-import threading
 import tkinter as tk
 from tkinter import ttk, filedialog
 
@@ -55,10 +54,9 @@ def register_plugin(plugin_api):
             else name_var.get().strip() or "archive"
         )
         drop_area.set_files(paths)
-        threading.Thread(
+        plugin_api.start_thread(
             target=process_archives,
             args=(paths, action, output, plugin_api.app),
-            daemon=True,
-        ).start()
+        )
 
     drop_area.dnd_bind("<<Drop>>", handle_drop)

--- a/plugins/plugins/audio_plugin.py
+++ b/plugins/plugins/audio_plugin.py
@@ -1,7 +1,6 @@
 import os
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
-import threading
 import logging
 from utils.file_helpers import find_files_in_folder, create_drop_area
 from constants import VALID_EXTENSIONS
@@ -112,7 +111,7 @@ def register_plugin(plugin_api):
             messagebox.showerror("Error", "No valid audio files found.")
             return
         drop_area.set_files(audio_files)
-        t = threading.Thread(
+        plugin_api.start_thread(
             target=process_audio_files,
             args=(
                 audio_files,
@@ -123,9 +122,7 @@ def register_plugin(plugin_api):
                 normalize_var.get(),
                 plugin_api.app,
             ),
-            daemon=True,
         )
-        t.start()
 
     drop_area.dnd_bind("<<Drop>>", audio_drop_event)
 
@@ -136,21 +133,19 @@ def register_plugin(plugin_api):
         )
         if not files:
             return
-        threading.Thread(
+        plugin_api.start_thread(
             target=process_audio_files,
             args=(files, "mp3", 128, True, True, True, plugin_api.app),
-            daemon=True,
-        ).start()
+        )
 
     def run_voiceover_preset():
         files = tk.filedialog.askopenfilenames(filetypes=[("Audio", "*.wav;*.flac")])
         if not files:
             return
-        threading.Thread(
+        plugin_api.start_thread(
             target=process_audio_files,
             args=(files, "wav", 192, True, False, True, plugin_api.app),
-            daemon=True,
-        ).start()
+        )
 
     plugin_api.register_hook("preset:Podcast", run_podcast_preset)
     plugin_api.register_hook("preset:Voiceover", run_voiceover_preset)

--- a/plugins/plugins/audio_separator_plugin.py
+++ b/plugins/plugins/audio_separator_plugin.py
@@ -125,7 +125,10 @@ class AudioSeparatorUI:
             cmd.insert(1, f"--two-stems={self.target.get()}")
 
         self.console_dmx.delete("1.0", tk.END)
-        threading.Thread(target=run_command, args=(cmd, self.console_dmx, threading.Event()), daemon=True).start()
+        self.api.start_thread(
+            target=run_command,
+            args=(cmd, self.console_dmx, threading.Event()),
+        )
 
     def run_dpf(self):
         inp = self.dpf_in.get()
@@ -194,7 +197,7 @@ class AudioSeparatorUI:
             shutil.rmtree(tmpdir)
 
         self.console_dpf.delete("1.0", tk.END)
-        threading.Thread(target=chunk_process, daemon=True).start()
+        self.api.start_thread(target=chunk_process)
 
 def register_plugin(plugin_api):
     tab = ttk.Frame(plugin_api.app.notebook)

--- a/plugins/plugins/file_organizer_plugin.py
+++ b/plugins/plugins/file_organizer_plugin.py
@@ -255,7 +255,7 @@ class OrganizerUI:
             "interval": self.interval.get(),
         }
         _save_prefs(data)
-        threading.Thread(target=self._scan, daemon=True).start()
+        self.api.start_thread(target=self._scan)
 
     def _scan(self):
         self.api.trigger_hook("organizer_pre_scan", self.paths)

--- a/plugins/plugins/html_to_pdf_plugin.py
+++ b/plugins/plugins/html_to_pdf_plugin.py
@@ -300,9 +300,10 @@ class HtmlToPdfPlugin(ttk.Frame):
         self.log_text.delete(1.0, tk.END)
         self.progress_bar["value"] = 0
         self.cancel_event = threading.Event()
-        threading.Thread(
-            target=self.run_generate, args=(url, out_filename, chrome_path), daemon=True
-        ).start()
+        self.api.start_thread(
+            target=self.run_generate,
+            args=(url, out_filename, chrome_path),
+        )
 
     def on_cancel(self):
         if self.cancel_event:

--- a/plugins/plugins/image_plugin.py
+++ b/plugins/plugins/image_plugin.py
@@ -1,7 +1,6 @@
 import os
 import tkinter as tk
 from tkinter import ttk, messagebox
-import threading
 import logging
 from utils.file_helpers import find_files_in_folder, create_drop_area
 from constants import VALID_EXTENSIONS
@@ -166,7 +165,7 @@ def register_plugin(plugin_api):
             messagebox.showerror("Error", "No valid image files found.")
             return
         drop_area.set_files(image_files)
-        t = threading.Thread(
+        plugin_api.start_thread(
             target=process_images,
             args=(
                 image_files,
@@ -183,8 +182,6 @@ def register_plugin(plugin_api):
                 new_format_var.get(),
                 plugin_api.app,
             ),
-            daemon=True,
         )
-        t.start()
 
     drop_area.dnd_bind("<<Drop>>", image_drop_event)

--- a/plugins/plugins/pdf_plugin.py
+++ b/plugins/plugins/pdf_plugin.py
@@ -1,7 +1,6 @@
 """PDF merging and splitting plugin."""
 
 import os
-import threading
 import tkinter as tk
 from tkinter import ttk, messagebox
 
@@ -48,17 +47,15 @@ def register_plugin(plugin_api):
             return
         drop_area.set_files(pdf_files)
         if action_var.get() == "merge":
-            threading.Thread(
+            plugin_api.start_thread(
                 target=merge_pdfs,
                 args=(pdf_files, name_var.get().strip() or "output", plugin_api.app),
-                daemon=True,
-            ).start()
+            )
         else:
             # use first file for split
-            threading.Thread(
+            plugin_api.start_thread(
                 target=split_pdf,
                 args=(pdf_files[0], start_var.get(), end_var.get(), plugin_api.app),
-                daemon=True,
-            ).start()
+            )
 
     drop_area.dnd_bind("<<Drop>>", handle_drop)

--- a/plugins/plugins/text_plugin.py
+++ b/plugins/plugins/text_plugin.py
@@ -1,7 +1,6 @@
 import os
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
-import threading
 import logging
 import markdown
 import json
@@ -68,7 +67,7 @@ def register_plugin(plugin_api):
             messagebox.showerror("Error", "No valid text files found.")
             return
         drop_area.set_files(text_files)
-        t = threading.Thread(
+        plugin_api.start_thread(
             target=process_text_files,
             args=(
                 text_files,
@@ -80,9 +79,7 @@ def register_plugin(plugin_api):
                 freq_stats_var.get(),
                 plugin_api.app,
             ),
-            daemon=True,
         )
-        t.start()
 
     drop_area.dnd_bind("<<Drop>>", text_drop_event)
 


### PR DESCRIPTION
## Summary
- expose `AppCore.start_thread` for thread tracking
- delegate plugin threads to `AppCore` via `PluginAPI.start_thread`
- track tray thread with the new helper
- refactor image and archive plugins to register worker threads
- document thread tracking in README and AGENTS
- mark completed task in code_analysis log

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for multiple modules)*

------
https://chatgpt.com/codex/tasks/task_e_6850ad2e8058832f9960f1f5b1f6ad1d