### PR TITLE
Improve plugin imports and test setup

### DIFF
--- a/plugins/plugins/audio_plugin.py
+++ b/plugins/plugins/audio_plugin.py
@@ -1,6 +1,6 @@
 import os
 import tkinter as tk
-from tkinter import ttk, messagebox, filedialog
+from tkinter import ttk, messagebox
 import logging
 from utils.file_helpers import find_files_in_folder, create_drop_area
 from constants import VALID_EXTENSIONS

--- a/plugins/plugins/audio_separator.py
+++ b/plugins/plugins/audio_separator.py
@@ -173,7 +173,7 @@ class App(tk.Tk):
                     self.console_dpf.insert(tk.END, f"❌ Chunk {i + 1} failed to produce output.\n\n")
 
             if not outputs:
-                self.console_dpf.insert(tk.END, f"❌ No chunks processed successfully. Aborting.\n")
+                self.console_dpf.insert(tk.END, "❌ No chunks processed successfully. Aborting.\n")
                 return
 
             self.console_dpf.insert(tk.END, f"\n🔄 Reassembling {len(outputs)} chunks...\n")

--- a/plugins/plugins/audio_separator_plugin.py
+++ b/plugins/plugins/audio_separator_plugin.py
@@ -180,7 +180,7 @@ class AudioSeparatorUI:
                     self.console_dpf.insert(tk.END, f"❌ Chunk {i + 1} failed to produce output.\n\n")
 
             if not outputs:
-                self.console_dpf.insert(tk.END, f"❌ No chunks processed successfully. Aborting.\n")
+                self.console_dpf.insert(tk.END, "❌ No chunks processed successfully. Aborting.\n")
                 return
 
             self.console_dpf.insert(tk.END, f"\n🔄 Reassembling {len(outputs)} chunks...\n")

--- a/plugins/plugins/pdf_plugin.py
+++ b/plugins/plugins/pdf_plugin.py
@@ -1,6 +1,5 @@
 """PDF merging and splitting plugin."""
 
-import os
 import tkinter as tk
 from tkinter import ttk, messagebox
 

--- a/plugins/plugins/text_plugin.py
+++ b/plugins/plugins/text_plugin.py
@@ -2,10 +2,6 @@ import os
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 import logging
-import markdown
-import json
-import csv
-import yaml
 from utils.file_helpers import create_drop_area, find_files_in_folder, read_file_content
 from constants import VALID_EXTENSIONS
 from processors.text_processor import process_text_files

--- a/plugins/plugins/video_plugin.py
+++ b/plugins/plugins/video_plugin.py
@@ -3,7 +3,6 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 import logging
 from concurrent.futures import ThreadPoolExecutor
-import threading
 from utils.file_helpers import create_drop_area, find_files_in_folder
 from constants import VALID_EXTENSIONS
 from processors.video_processor import process_videos, join_multiple_clips

--- a/processors/video_processor.py
+++ b/processors/video_processor.py
@@ -3,7 +3,6 @@ import logging
 from utils.file_helpers import ensure_file_output_dir, generate_unique_file_path
 from utils.ffmpeg_helpers import run_ffmpeg_command, is_gpu_available
 from utils.diagnostics import increment_usage, time_block
-from constants import VALID_EXTENSIONS
 
 
 USE_GPU = is_gpu_available()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))


### PR DESCRIPTION
## Summary
- add conftest to ensure tests import project packages
- remove unused imports across plugins
- fix f-string without placeholders in audio separator modules
- clean up video processor imports

## Testing
- `xvfb-run -a pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850bbaa8a50832f951b780be0e5a460