### PR TITLE
Improve UI layout and handle headless tray

### DIFF
--- a/agents/tray_agent.py
+++ b/agents/tray_agent.py
@@ -1,7 +1,12 @@
 import threading
 import logging
-import pystray
-from pystray import MenuItem as Item, Menu
+try:
+    import pystray
+    from pystray import MenuItem as Item, Menu
+except Exception as e:  # noqa: BLE001
+    pystray = None
+    Item = Menu = None
+    logging.getLogger(__name__).warning("pystray not available: %s", e)
 from PIL import Image, ImageDraw
 
 logger = logging.getLogger(__name__)
@@ -12,8 +17,18 @@ class TrayAgent:
 
     def __init__(self, app) -> None:
         self.app = app
-        self.icon = pystray.Icon("MUT", self._create_image(), "Multi-Utility Tool")
-        self.icon.menu = self._build_menu()
+        if pystray is None:
+            logger.warning("Tray functionality disabled; pystray unavailable")
+            self.icon = None
+            return
+        try:
+            self.icon = pystray.Icon(
+                "MUT", self._create_image(), "Multi-Utility Tool"
+            )
+            self.icon.menu = self._build_menu()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Failed to initialize tray icon: %s", e)
+            self.icon = None
 
     def _create_image(self):
         image = Image.new("RGB", (64, 64), "black")
@@ -40,17 +55,24 @@ class TrayAgent:
         return menu
 
     def show(self) -> None:
+        if self.icon is None:
+            logger.debug("Tray icon disabled; not showing")
+            return
         if hasattr(self.app, "start_thread"):
             self.app.start_thread(target=self.icon.run)
         else:  # fallback
             threading.Thread(target=self.icon.run, daemon=True).start()
 
     def _restore(self, icon=None, item=None):
+        if not self.icon:
+            return
         logger.info("Restoring window from tray")
         self.icon.stop()
         self.app.root.after(0, self.app.root.deiconify)
 
     def _exit(self, icon=None, item=None):
+        if not self.icon:
+            return
         logger.info("Exiting from tray menu")
         self.icon.stop()
         self.app.root.after(0, self.app.root.quit)
@@ -60,6 +82,9 @@ class TrayAgent:
         self.app.plugins.api.trigger_hook(f"preset:{preset}")
 
     def notify(self, message: str) -> None:
+        if not self.icon:
+            logger.debug("Tray icon not initialized; notification skipped")
+            return
         try:
             self.icon.notify(message)
         except Exception:

--- a/agents/ui_agent.py
+++ b/agents/ui_agent.py
@@ -46,6 +46,8 @@ class UIAgent:
         self.style.configure(
             "TNotebook.Tab", background="#3e3e3e", foreground="#d3d3d3"
         )
+        # Hide tab bar for a cleaner look; navigation handled by sidebar
+        self.style.layout("TNotebook.Tab", [])
 
         self.queue: Queue = Queue()
         self.plugin_tabs: dict[str, tk.Frame] = {}
@@ -60,12 +62,24 @@ class UIAgent:
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
 
     def setup_tabs(self) -> None:
-        self.notebook = ttk.Notebook(self.root)
-        self.notebook.pack(expand=True, fill="both")
+        container = ttk.Frame(self.root)
+        container.pack(expand=True, fill="both")
+        self.sidebar = tk.Listbox(container, exportselection=False, width=20)
+        self.sidebar.pack(side=tk.LEFT, fill=tk.Y)
+        self.sidebar.bind("<<ListboxSelect>>", self._on_plugin_select)
+        self.notebook = ttk.Notebook(container)
+        self.notebook.pack(side=tk.RIGHT, expand=True, fill="both")
 
     def add_plugin_tab(self, title: str, frame: tk.Frame) -> None:
         self.notebook.add(frame, text=title)
+        self.sidebar.insert(tk.END, title)
         self.plugin_tabs[title] = frame
+
+    def _on_plugin_select(self, event=None) -> None:
+        idx = self.sidebar.curselection()
+        if not idx:
+            return
+        self.notebook.select(idx[0])
 
     def setup_menu(self) -> None:
         self.menu_bar = tk.Menu(self.root)
@@ -130,6 +144,10 @@ class UIAgent:
             "About", "Multi-Utility Tool with Plugin Support\nVersion 1.0\n© 2023"
         )
 
+    def show_error(self, message: str) -> None:
+        messagebox.showerror("Error", message)
+        logger.error(message)
+
     def update_status(self, message: str) -> None:
         self.status_var.set(message)
         logger.info(message)
@@ -155,6 +173,8 @@ class UIAgent:
                     self.stop_progress()
                     self.update_status(payload)
                     self.app.tray.notify(payload)
+                elif msg_type == "error":
+                    self.show_error(payload)
         except Empty:
             pass
         self.root.after(50, self.process_queue)
@@ -174,5 +194,6 @@ class UIAgent:
         for t in getattr(self.app, "threads", []):
             if t.is_alive():
                 t.join(timeout=1)
-        self.app.tray.icon.stop()
+        if getattr(self.app.tray, "icon", None):
+            self.app.tray.icon.stop()
         self.root.destroy()


### PR DESCRIPTION
## Summary
- add sidebar-based navigation to `UIAgent`
- hide notebook tabs for a cleaner look
- report errors via a new `show_error` method
- support environments without a display by guarding tray icon initialization

## Testing
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6850be06a880832fb5d2946c562c3be4