### PR TITLE
Add dependency health checks to app startup

### DIFF
--- a/core/app_core.py
+++ b/core/app_core.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable
+from typing import Iterable, Sequence
 
 from agents.hotkey_agent import HotkeyAgent
 from agents.logger_agent import LoggerAgent
@@ -13,12 +13,16 @@ from agents.ui_agent import UIAgent
 from agents.null_agents import NullHotkeyAgent, NullTrayAgent
 from core.plugin_manifest import PluginManifest
 from core.task_manager import TaskManager
+from utils.health_checks import check_dependencies, summarize_failures, DependencyStatus
 
 logger = logging.getLogger(__name__)
 
 
 class AppCore:
     """Central coordinator that wires individual agents together."""
+
+    REQUIRED_DEPENDENCIES: Sequence[str] = ("yaml", "requests")
+    OPTIONAL_DEPENDENCIES: Sequence[str] = ("keyboard", "pystray", "tkinterdnd2")
 
     def __init__(
         self,
@@ -28,12 +32,15 @@ class AppCore:
         enable_tray: bool = True,
         worker_count: int | None = None,
         load_plugins: bool = True,
+        dependencies: Sequence[tuple[str, bool]] | None = None,
     ) -> None:
         self.logger_agent = LoggerAgent()
         self.logger = logging.getLogger("app")
         self.tasks = TaskManager(max_workers=worker_count)
         self.headless = headless
         self.threads: list = []
+        self.dependency_statuses: list[DependencyStatus] = []
+        self.dependency_failures: list[str] = []
 
         self.ui = UIAgent(self, headless=headless)
         self.root = self.ui.root
@@ -46,10 +53,41 @@ class AppCore:
             TrayAgent(self) if enable_tray and not headless else NullTrayAgent(self)
         )
         self.ui.attach()
+        self._run_dependency_checks(dependencies)
         logger.info("App core initialized")
 
     def register_thread(self, thread) -> None:
         self.threads.append(thread)
+
+    def _run_dependency_checks(
+        self, dependencies: Sequence[tuple[str, bool]] | None = None
+    ) -> None:
+        """Execute startup dependency checks and surface any critical issues."""
+
+        dependency_plan = dependencies or [
+            *[(dep, True) for dep in self.REQUIRED_DEPENDENCIES],
+            *[(dep, False) for dep in self.OPTIONAL_DEPENDENCIES],
+        ]
+        self.dependency_statuses = check_dependencies(dependency_plan)
+        self.dependency_failures = summarize_failures(self.dependency_statuses)
+
+        for status in self.dependency_statuses:
+            level = logger.info if status.installed else logger.warning
+            level(
+                "Dependency %s (%s): %s",
+                status.name,
+                "required" if status.required else "optional",
+                status.message,
+            )
+
+        if self.dependency_failures:
+            for message in self.dependency_failures:
+                logger.error(message)
+            self._notify_missing_dependencies(self.dependency_failures)
+
+        missing_optional = [s.name for s in self.dependency_statuses if not s.required and not s.installed]
+        if missing_optional:
+            logger.info("Optional features downgraded; missing: %s", ", ".join(sorted(missing_optional)))
 
     def shutdown(self) -> None:
         """Gracefully stop all background resources."""
@@ -64,6 +102,25 @@ class AppCore:
         for thread in list(self.threads):
             if thread.is_alive():
                 thread.join(timeout=1.0)
+
+    def _notify_missing_dependencies(self, messages: Sequence[str]) -> None:
+        """Surface dependency issues via UI/tray when available while staying resilient in headless/test modes."""
+
+        combined = "; ".join(messages)
+        if self.headless:
+            logger.warning("Headless mode: %s", combined)
+            return
+
+        try:
+            self.ui.queue.put((self, "toast", combined))
+        except Exception:  # pragma: no cover - guard against UI failures
+            logger.debug("Failed to enqueue UI notification", exc_info=True)
+
+        try:
+            if hasattr(self.tray, "notify"):
+                self.tray.notify(combined)
+        except Exception:  # pragma: no cover - guard against platform-specific tray issues
+            logger.debug("Failed to send tray notification", exc_info=True)
 
     # Delegate tab addition for plugins
     def add_plugin_tab(

--- a/tests/test_app_core_dependencies.py
+++ b/tests/test_app_core_dependencies.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from queue import Queue
+
+import pytest
+
+from core import app_core as app_core_module
+from core.app_core import AppCore
+from utils.health_checks import DependencyStatus
+
+
+class DummyRoot:
+    def after(self, *_args, **_kwargs):
+        return None
+
+
+class DummyUI:
+    def __init__(self, app, headless: bool = False):
+        self.app = app
+        self.headless = headless
+        self.queue: Queue = Queue()
+        self.root = DummyRoot()
+        self.notebook = None
+
+    def attach(self) -> None:
+        return None
+
+
+class DummyTray:
+    def __init__(self, app):
+        self.app = app
+        self.notifications: list[str] = []
+
+    def notify(self, message: str) -> None:
+        self.notifications.append(message)
+
+
+@pytest.fixture(autouse=True)
+def patch_ui_and_tray(monkeypatch):
+    monkeypatch.setattr(app_core_module, "UIAgent", DummyUI)
+    monkeypatch.setattr(app_core_module, "TrayAgent", DummyTray)
+
+
+def test_dependency_check_healthy(monkeypatch):
+    statuses = [
+        DependencyStatus("dep_a", True, True, "1.0.0", "OK"),
+        DependencyStatus("dep_b", False, True, "2.0.0", "OK"),
+    ]
+    monkeypatch.setattr(app_core_module, "check_dependencies", lambda deps: statuses)
+
+    app = AppCore(
+        headless=True,
+        enable_hotkeys=False,
+        enable_tray=False,
+        load_plugins=False,
+    )
+
+    assert app.dependency_statuses == statuses
+    assert app.dependency_failures == []
+
+
+def test_dependency_check_missing_required(monkeypatch):
+    statuses = [
+        DependencyStatus("critical", True, False, None, "Not installed"),
+        DependencyStatus("optional", False, True, "1.0.0", "OK"),
+    ]
+    monkeypatch.setattr(app_core_module, "check_dependencies", lambda deps: statuses)
+
+    app = AppCore(
+        headless=False,
+        enable_hotkeys=False,
+        enable_tray=True,
+        load_plugins=False,
+    )
+
+    assert app.dependency_failures == ["Missing required dependency: critical"]
+    queued = list(app.ui.queue.queue)
+    assert queued and queued[0][1] == "toast"
+    assert app.tray.notifications == ["Missing required dependency: critical"]
+
+
+def test_dependency_check_missing_optional(monkeypatch):
+    statuses = [
+        DependencyStatus("dep_a", True, True, "1.0.0", "OK"),
+        DependencyStatus("opt", False, False, None, "Not installed"),
+    ]
+    monkeypatch.setattr(app_core_module, "check_dependencies", lambda deps: statuses)
+
+    app = AppCore(
+        headless=True,
+        enable_hotkeys=False,
+        enable_tray=False,
+        load_plugins=False,
+    )
+
+    assert app.dependency_failures == []
+    assert any(not status.required and not status.installed for status in app.dependency_statuses)


### PR DESCRIPTION
## Summary
- add dependency health checks during AppCore startup with configurable required and optional packages
- log missing dependencies and surface UI/tray notifications while protecting headless/test scenarios
- add unit coverage for healthy, missing required, and missing optional dependency paths

## Testing
- pytest tests/test_app_core_dependencies.py tests/test_agents.py tests/test_health_checks.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69424524a270832f88d6d4e7362cd18f)